### PR TITLE
Formatted `--help`, provided README documentation

### DIFF
--- a/benchmarks/stream/README.md
+++ b/benchmarks/stream/README.md
@@ -4,8 +4,6 @@ This modified version of the STREAM benchmarking tool measures the memory bandwi
 
 # Setup
 
-This benchmarking tool for measuring memory bandwidth requires  for the `numactl` command along with the `numa.h` header.
-
 The `numactl` command and `numa.h` header are required for this benchmark to run. The Debian verison of the package that provides both is [`libnuma-dev`](https://manpages.debian.org/buster/libnuma-dev/numa.3.en.html).
 
 # Usage

--- a/benchmarks/stream/README.md
+++ b/benchmarks/stream/README.md
@@ -1,110 +1,63 @@
-===============================================
+# STREAM
 
-STREAM is the de facto industry standard benchmark
-for measuring sustained memory bandwidth.
+This modified version of the STREAM benchmarking tool measures the memory bandwidth of numa nodes. The original source code can be found [here](https://www.cs.virginia.edu/stream/FTP/Code/).
 
-Documentation for STREAM is on the web at:
-   http://www.cs.virginia.edu/stream/ref.html
+# Setup
 
-===============================================
-NEWS
-===============================================
-UPDATE: October 28 2014:
+This benchmarking tool for measuring memory bandwidth requires  for the `numactl` command along with the `numa.h` header.
 
-"stream_mpi.c" released in the Versions directory.
+The `numactl` command and `numa.h` header are required for this benchmark to run. The Debian verison of the package that provides both is [`libnuma-dev`](https://manpages.debian.org/buster/libnuma-dev/numa.3.en.html).
 
-Based on Version 5.10 of stream.c, stream_mpi.c
-brings the following new features:
-* MPI implementation that *distributes* the arrays
-  across all MPI ranks. (The older Fortran version
-  of STREAM in MPI *replicates* the arrays across
-  all MPI ranks.)
-* Data is allocated using "posix_memalign" 
-  rather than using static arrays.  Different
-  compiler flags may be needed for both portability
-  and optimization.
-  See the READ.ME file in the Versions directory
-  for more details.
-* Error checking and timing done by all ranks and
-  gathered by rank 0 for processing and output.
-* Timing code uses barriers to ensure correct
-  operation even when multiple MPI ranks run on
-  shared memory systems.
+# Usage
 
-NOTE: MPI is not a preferred implementation for
-  STREAM, which is intended to measure memory
-  bandwidth in shared-memory systems.  In stream_mpi,
-  the MPI calls are only used to properly synchronize
-  the timers (using MPI_Barrier) and to gather
-  timing and error data, so the performance should 
-  scale linearly with the size of the cluster.
-  But it may be useful, and was an interesting 
-  exercise to develop and debug.
+## Compiling
 
-===============================================
-UPDATE: January 17 2013:
+- Debug, sanitizers, no optimization: `make debug_stream_c.exe`
+- Optimization level 3: `make stream_c.exe`
 
-Version 5.10 of stream.c is finally available!
+## Running
 
-There are no changes to what is being measured, but
-a number of long-awaited improvements have been made:
+### Command information
 
-* Updated validation code does not suffer from 
-  accumulated roundoff error for large arrays.
-* Defining the preprocessor variable "VERBOSE"
-  when compiling will (1) cause the code to print the
-  measured average relative absolute error (rather than
-  simply printing "Solution Validates", and (2) print
-  the first 10 array entries with relative error exceeding
-  the error tolerance.
-* Array index variables have been upgraded from
-  "int" to "ssize_t" to allow arrays with more
-  than 2 billion elements on 64-bit systems.
-* Substantial improvements to the comments in 
-  the source on how to configure/compile/run the
-  benchmark.
-* The proprocessor variable controlling the array
-  size has been changed from "N" to "STREAM_ARRAY_SIZE".
-* A new preprocessor variable "STREAM_TYPE" can be
-  used to override the data type from the default
-  "double" to "float".
-  This mechanism could also be used to change to 
-  non-floating-point types, but several "printf"
-  statements would need to have their formats changed
-  to accomodate the modified data type.
-* Some small changes in output, including printing
-  array sizes is GiB as well as MiB.
-* Change to the default output format to print fewer
-  decimals for the bandwidth and more decimals for
-  the min/max/avg execution times.
+```bash
+$ ./stream_c.exe --help
+STREAM Benchmark
+         --ntimes, -t <integer-value>                         : Number of times to run benchmark: Default 10
+     --array-size, -a <integer-value>|<integer-value><K|M|G>  : Size of numa node arrays: Default 1000000
+         --offset, -o <integer-value>                         : Change relative alignment of arrays: Default 0
+     --numa-nodes, -n <integer>,<integer>|<integer>           : [Required] Numa node(s) to do calculations on
+--auto-array-size, -s                                         : Array will be socket's L3 cache divided by 2
+           --help, -h                                         : Print this message
+```
 
+### Memory combinations
 
-===============================================
-UPDATE: February 19 2009:
+Get the indices of your numa nodes via the [`lscpu`](https://www.man7.org/linux/man-pages/man1/lscpu.1.html) command. An example being the following:
 
-The most recent "official" versions have been renamed
-"stream.f" and "stream.c" -- all other versions have
-been moved to the "Versions" subdirectory and should be
-considered obsolete.
+```
+NUMA:
+  NUMA node(s):          3
+  NUMA node0 CPU(s):     0-31,64-95
+  NUMA node1 CPU(s):     32-63,96-127
+  NUMA node2 CPU(s):
+```
 
-The "official" timer (was "second_wall.c") has been
-renamed "mysecond.c".   This is embedded in the C version
-("stream.c"), but still needs to be externally linked to
-the FORTRAN version ("stream.f").  The new version defines
-entry points both with and without trailing underscores,
-so it *should* link automagically with any Fortran compiler.
+The nodes with CPUs are DRAM (node0, node1), while the one without any CPUs (node2) is CXL.
 
-===============================================
+#### DRAM Only
 
-STREAM is a project of "Dr. Bandwidth":
-	John D. McCalpin, Ph.D.
-	john@mccalpin.com
+```bash
+$ numactl --cpunodebind=0 --membind=0,1 ./stream_c.exe --numa-nodes 0,1 --auto-array-size
+```
 
-===============================================
+#### CXL Only
 
-The STREAM web and ftp sites are currently hosted at
-the Department of Computer Science at the University of
-Virginia under the generous sponsorship of Professor Bill
-Wulf and Professor Alan Batson.
+```bash
+$ numactl --cpunodebind=0 --membind=2 ./stream_c.exe --numa-nodes 2 --auto-array-size
+```
 
-===============================================
+#### DRAM + CXL
+
+```bash
+$ numactl --cpunodebind=0 --membind=0,2 ./stream_c.exe --numa-nodes 0,2 --auto-array-size
+```

--- a/benchmarks/stream/stream.c
+++ b/benchmarks/stream/stream.c
@@ -178,8 +178,10 @@ static const int TIMES_LEN = 8;
 extern double mysecond();
 extern void checkSTREAMresults();
 extern uint64_t convert_array_size(char *);
+extern void output_help();
+extern uint64_t calculate_array_size();
 extern uint64_t *parse_cli_args(int, char **, uint64_t *);
-void parse_numa_from_cli(uint64_t **, char *);
+extern void parse_numa_from_cli(uint64_t **, char *);
 extern void upperbound_errors(int *, int *, double, STREAM_TYPE *, STREAM_TYPE,
                               STREAM_TYPE, char *);
 #ifdef TUNED
@@ -466,14 +468,19 @@ int main(int argc, char **argv) {
     return 0;
 }
 
-static const int HELP_LEN = 5;
+static const int HELP_LEN = 6;
 static char *HELP[] = {
-    "--ntimes <integer-value>                              Default value 10",
-    "--array-size <integer-value>|<integer-value><K|M|G>   Default value 1000000",
-    "--offset <integer-value>                              Default value 0",
-    "--numa-nodes <integer>,<integer>",
-    "--auto-array-size",
-    "--help"};
+    "         --ntimes, -t <integer-value>                         : Number of times to "
+    "run benchmark: Default 10",
+    "     --array-size, -a <integer-value>|<integer-value><K|M|G>  : Size of numa node "
+    "arrays: Default 1000000",
+    "         --offset, -o <integer-value>                         : Change relative "
+    "alignment of arrays: Default 0",
+    "     --numa-nodes, -n <integer>,<integer>|<integer>           : [Required] Numa "
+    "node(s) to do calculations on",
+    "--auto-array-size, -s                                         : Array will be "
+    "socket's L3 cache divided by 2",
+    "           --help, -h                                         : Print this message"};
 
 static struct option long_options[6] = {
     {"ntimes", optional_argument, 0, 't'},    {"array-size", optional_argument, 0, 'a'},
@@ -492,6 +499,15 @@ void parse_numa_from_cli(uint64_t **numa_nodes, char *arg) {
 
         free(s0);
     }
+}
+
+void output_help() {
+    printf("STREAM Benchmark\n");
+    for (int i = 0; i < HELP_LEN; i++) {
+        printf("%s\n", HELP[i]);
+    }
+
+    exit(EXIT_SUCCESS);
 }
 
 uint64_t calculate_array_size() {
@@ -545,9 +561,7 @@ uint64_t *parse_cli_args(int argc, char **argv, uint64_t *numa_nodes) {
             stream_array_size = calculate_array_size();
             break;
         case 'h':
-            printf("Stream Benchmark CLI Help\n\n");
-            for (int i = 0; i < HELP_LEN; i++)
-                printf("%s\n", HELP[i]);
+            output_help();
             break;
         default:
             break;


### PR DESCRIPTION
`--help` now looks much better (long flags are aligned and have descriptions), and the README now contains a setup section, along with examples of how to run the binary with numactl.