### PR TITLE
Consolidate all systeminfo  a single script

### DIFF
--- a/tools/showbios
+++ b/tools/showbios
@@ -1,3 +1,0 @@
-#!/usr/bin/env
-
-sudo dmidecode -t bios

--- a/tools/showdisktopo
+++ b/tools/showdisktopo
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash 
-
-lsblk -o NAME,SIZE,TYPE,MOUNTPOINTS,MODEL,VENDOR

--- a/tools/showprocessor
+++ b/tools/showprocessor
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash 
-
-sudo dmidecode -t processor

--- a/tools/showsysteminfo
+++ b/tools/showsysteminfo
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+function show_vgdisplay()
+{
+    sudo vgdisplay > vgdisplay
+}
+
+function show_hostname()
+{
+    hostname > hostname
+}
+
+function show_ip_address()
+{
+    ifconfig > ifconfig    
+}
+
+function show_os_release()
+{
+    cat /etc/*release* > lsb_release
+}
+
+function show_uname()
+{
+    uname -a > uname
+}
+
+function show_free_disk()
+{
+    df -H  > df
+}
+
+function show_free_memory()
+{
+    free > free
+}
+
+function show_bios()
+{
+    sudo dmidecode -t bios > bios
+}
+
+function show_processor()
+{
+    sudo dmidecode -t processor > processor
+}
+
+function show_disk_topo()
+{
+    lsblk -o NAME,SIZE,TYPE,MOUNTPOINTS,MODEL,VENDOR > lsblk
+}
+
+function show_numactl_h()
+{
+    numactl -H > numactl_h
+}
+
+show_bios
+show_numactl_h
+show_processor
+show_hostname
+show_uname
+show_os_release
+show_ip_address
+show_disk_topo
+show_free_disk
+show_vgdisplay
+show_free_memory


### PR DESCRIPTION
Add a number of system information into a single script.
Delete showbios, showprocessor and showdisktopo, which has been added to showsysteminfo