### PR TITLE
Graphing operations between different memory types

### DIFF
--- a/benchmarks/stream/Makefile
+++ b/benchmarks/stream/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -std=c17 -D_GNU_SOURCE -O3 -mavx2 -mavx512f
+CFLAGS = -std=c17 -D_GNU_SOURCE -O3 -mavx2 -mavx512f -fopenmp
 DEBUG_CFLAGS = -std=c17 -D_GNU_SOURCE -O0 -mavx2 -mavx512f -g -fsanitize=undefined,address
 
 WARNING_CFLAGS =  -Wall -Wformat-truncation=2 -Werror=return-type -Werror=overflow

--- a/benchmarks/stream/scripts/graph_array_sizes.py
+++ b/benchmarks/stream/scripts/graph_array_sizes.py
@@ -21,7 +21,7 @@ def main() -> None:
     parser.add_argument('csv_file', type=file_exists,
                         help='CSV file to process')
 
-    parser.add_argument('dir', type=file_exists,
+    parser.add_argument('dir', type=str,
                         help='Directory to dump all the graphs into')
 
     args = parser.parse_args()

--- a/benchmarks/stream/scripts/graph_array_sizes.py
+++ b/benchmarks/stream/scripts/graph_array_sizes.py
@@ -3,6 +3,8 @@ import matplotlib.pyplot as plt
 import os
 from pathlib import Path
 import argparse
+import numpy as np
+from scipy.interpolate import make_interp_spline
 
 
 def file_exists(file: str) -> Path:
@@ -54,13 +56,10 @@ def main() -> None:
 
             x, y = tmp_df.index, tmp_df.values
 
-            ax.plot(x, y, label=function)
-
-            # Smoothing the graph
-            # x_new = np.linspace(x.min(), x.max(), 100)
-            # spline = make_interp_spline(x, y)
-            # y_smooth = spline(x_new)
-            # plt.plot(x_new, y_smooth, label=function)
+            x_new = np.linspace(x.min(), x.max(), 300)
+            spline = make_interp_spline(x, y)
+            y_smooth = spline(x_new)
+            ax.plot(x_new, y_smooth, label=function)
 
         # https://stackoverflow.com/a/4701285 (setting legend outside plot)
         box = ax.get_position()

--- a/benchmarks/stream/scripts/graph_array_sizes.py
+++ b/benchmarks/stream/scripts/graph_array_sizes.py
@@ -40,6 +40,9 @@ def main() -> None:
     for array_size in array_sizes:
         filtered = df[df["ArraySize"] == array_size]
 
+        fig = plt.figure()
+        ax = plt.subplot(111)
+
         for function in functions:
             tmp_df: pd.DataFrame = (
                 # https://stackoverflow.com/a/27975230 (Filtering by row value)
@@ -51,7 +54,7 @@ def main() -> None:
 
             x, y = tmp_df.index, tmp_df.values
 
-            plt.plot(x, y, label=function)
+            ax.plot(x, y, label=function)
 
             # Smoothing the graph
             # x_new = np.linspace(x.min(), x.max(), 100)
@@ -59,14 +62,20 @@ def main() -> None:
             # y_smooth = spline(x_new)
             # plt.plot(x_new, y_smooth, label=function)
 
-        plt.xlabel("Threads")
-        plt.ylabel("Best Rate (MB/s)")
-        plt.title(f"Array size: {array_size}")
-        plt.legend()
+        # https://stackoverflow.com/a/4701285 (setting legend outside plot)
+        box = ax.get_position()
+        ax.set_position([box.x0, box.y0 + box.height * 0.1,
+                        box.width, box.height * 0.9])
+        ax.legend(loc='upper center', bbox_to_anchor=(0.5, -0.125),
+                  fancybox=True, shadow=True, ncol=5)
+
+        ax.set_xlabel("Threads")
+        ax.set_ylabel("Best Rate (MB/s)")
+        ax.set_title(f"Array size: {array_size}")
 
         f = dir + f"{array_size}.png"
-        plt.savefig(f)
-        plt.clf()
+        fig.savefig(f)
+        fig.clf()
 
 
 if __name__ == "__main__":

--- a/benchmarks/stream/scripts/graph_operations.py
+++ b/benchmarks/stream/scripts/graph_operations.py
@@ -1,8 +1,10 @@
 import pandas as pd
 import matplotlib.pyplot as plt
-import os
 from pathlib import Path
 import argparse
+import numpy as np
+from scipy.interpolate import make_interp_spline
+import os
 
 
 def file_exists(file: str) -> Path:
@@ -19,6 +21,9 @@ def main() -> None:
         description="Create graphs from previously generated CSV files"
     )
 
+    parser.add_argument("function", type=str, help="The function to plot")
+    parser.add_argument("array_size", type=int, help="The array size to plot")
+
     parser.add_argument("dram_csv_file", type=file_exists,
                         help="CSV file to process")
 
@@ -34,10 +39,13 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    # dir = args.dir
+    function_filter = args.function
+    array_size = args.array_size
 
-    # if not os.path.isdir(dir):
-    #     os.makedirs(dir)
+    directory = args.dir
+
+    if not os.path.isdir(directory):
+        os.makedirs(directory)
 
     dram_csv_file, cxl_csv_file, dram_cxl_csv_file = (
         args.dram_csv_file,
@@ -46,34 +54,64 @@ def main() -> None:
     )
 
     dram_df = pd.read_csv(dram_csv_file).iloc[:, 0:4]
-    dram_df["MemoryType"] = "DRAM"
 
     cxl_df = pd.read_csv(cxl_csv_file).iloc[:, 0:4]
-    cxl_df["MemoryType"] = "CXL"
 
     combined_df = pd.read_csv(dram_cxl_csv_file).iloc[:, 0:4]
 
     # https://stackoverflow.com/a/67148732 (filtering via index)
-    dram_cxl_df = combined_df[combined_df.index.map(
+    dram_cxl_df = combined_df.copy()[combined_df.index.map(
         lambda i: i % 8 in (0, 2, 5, 7))]
-    dram_cxl_df["MemoryType"] = "DRAM_CXL"
 
-    cxl_dram_df = combined_df[combined_df.index.map(
+    cxl_dram_df = combined_df.copy()[combined_df.index.map(
         lambda i: i % 8 in (1, 3, 4, 6))]
-    cxl_dram_df["MemoryType"] = "CXL_DRAM"
+
+    dram_df["MemoryType"] = "DRAM"
+    cxl_df["MemoryType"] = "CXL"
+    dram_cxl_df["MemoryType"] = "DRAM to CXL"
+    cxl_dram_df["MemoryType"] = "CXL to DRAM"
+
+    print(cxl_dram_df)
 
     df = pd.concat([dram_df, cxl_df, dram_cxl_df, cxl_dram_df])
 
-    print(df.to_string(max_rows=None))
+    filtered = df[df["ArraySize"] == array_size]
+    filtered = filtered[filtered["Function"] == function_filter]
 
-    # array_sizes = df["ArraySize"].drop_duplicates()
-    # functions = df["Function"].drop_duplicates()
+    memory_types = df["MemoryType"].drop_duplicates()
 
-    # for array_size in array_sizes:
-    #     filtered = df[df["ArraySize"] == array_size]
+    fig = plt.figure()
+    ax = plt.subplot(111)
 
-    #     for function in functions:
-    #         tmp_df = pd.DataFrame = ()
+    for memory in memory_types:
+        tmp_df: pd.DataFrame = (
+            filtered[filtered["MemoryType"].str.contains(memory)]
+            .drop(columns=["MemoryType"])
+            .groupby(["Threads"])["BestRateMBs"]
+            .mean()
+        )
+
+        x, y = tmp_df.index, tmp_df.values
+
+        x_new = np.linspace(x.min(), x.max(), 300)
+        spline = make_interp_spline(x, y)
+        y_smooth = spline(x_new)
+        ax.plot(x_new, y_smooth, label=memory)
+
+    # https://stackoverflow.com/a/4701285 (setting legend outside plot)
+    box = ax.get_position()
+    ax.set_position([box.x0, box.y0 + box.height * 0.1,
+                    box.width, box.height * 0.9])
+    ax.legend(loc='upper center', bbox_to_anchor=(0.5, -0.125),
+              fancybox=True, shadow=True, ncol=5)
+
+    ax.set_xlabel("Threads")
+    ax.set_ylabel("Best Rate (MB/s)")
+    ax.set_title(f"Function: {function_filter}, Array size: {array_size}")
+
+    f = directory + f"{function_filter}-{array_size}.png"
+    fig.savefig(f)
+    fig.clf()
 
 
 if __name__ == "__main__":

--- a/benchmarks/stream/scripts/graph_operations.py
+++ b/benchmarks/stream/scripts/graph_operations.py
@@ -45,24 +45,26 @@ def main() -> None:
         args.dram_cxl_csv_file,
     )
 
-    # dram_df = pd.read_csv(dram_csv_file).iloc[:, 0:4]
-    # dram_df["MemoryType"] = "DRAM"
+    dram_df = pd.read_csv(dram_csv_file).iloc[:, 0:4]
+    dram_df["MemoryType"] = "DRAM"
 
-    # cxl_df = pd.read_csv(cxl_csv_file).iloc[:, 0:4]
-    # cxl_df["MemoryType"] = "CXL"
+    cxl_df = pd.read_csv(cxl_csv_file).iloc[:, 0:4]
+    cxl_df["MemoryType"] = "CXL"
 
-    dram_cxl_df = pd.read_csv(dram_cxl_csv_file).iloc[:, 0:4]
+    combined_df = pd.read_csv(dram_cxl_csv_file).iloc[:, 0:4]
+
+    # https://stackoverflow.com/a/67148732 (filtering via index)
+    dram_cxl_df = combined_df[combined_df.index.map(
+        lambda i: i % 8 in (0, 2, 5, 7))]
     dram_cxl_df["MemoryType"] = "DRAM_CXL"
 
-    # https://stackoverflow.com/a/67148732
-    # TODO: Correct this so that indices 0, 2, 5, and 7 from 8 row blocks are captured
-    # TODO:     for reading DRAM to write to CXL
-    new = dram_cxl_df[dram_cxl_df.index.map(lambda i: i % 8 in (0, 2, 5, 7))]
-    print(new.to_string(max_rows=None))
+    cxl_dram_df = combined_df[combined_df.index.map(
+        lambda i: i % 8 in (1, 3, 4, 6))]
+    cxl_dram_df["MemoryType"] = "CXL_DRAM"
 
-    # df = pd.concat([dram_df, cxl_df, dram_cxl_df])
+    df = pd.concat([dram_df, cxl_df, dram_cxl_df, cxl_dram_df])
 
-    # print(df)
+    print(df.to_string(max_rows=None))
 
     # array_sizes = df["ArraySize"].drop_duplicates()
     # functions = df["Function"].drop_duplicates()
@@ -72,8 +74,6 @@ def main() -> None:
 
     #     for function in functions:
     #         tmp_df = pd.DataFrame = ()
-
-    # print(df)
 
 
 if __name__ == "__main__":

--- a/benchmarks/stream/scripts/graph_operations.py
+++ b/benchmarks/stream/scripts/graph_operations.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+import os
+from pathlib import Path
+import argparse
+
+
+def file_exists(file: str) -> Path:
+    path = Path(file)
+
+    if not path.is_file():
+        raise argparse.ArgumentTypeError(f"File '{file}' does not exist.")
+
+    return path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create graphs from previously generated CSV files"
+    )
+
+    parser.add_argument("dram_csv_file", type=file_exists,
+                        help="CSV file to process")
+
+    parser.add_argument("cxl_csv_file", type=file_exists,
+                        help="CSV file to process")
+
+    parser.add_argument(
+        "dram_cxl_csv_file", type=file_exists, help="CSV file to process"
+    )
+
+    parser.add_argument(
+        "dir", type=str, help="Directory to dump all the graphs into")
+
+    args = parser.parse_args()
+
+    # dir = args.dir
+
+    # if not os.path.isdir(dir):
+    #     os.makedirs(dir)
+
+    dram_csv_file, cxl_csv_file, dram_cxl_csv_file = (
+        args.dram_csv_file,
+        args.cxl_csv_file,
+        args.dram_cxl_csv_file,
+    )
+
+    # dram_df = pd.read_csv(dram_csv_file).iloc[:, 0:4]
+    # dram_df["MemoryType"] = "DRAM"
+
+    # cxl_df = pd.read_csv(cxl_csv_file).iloc[:, 0:4]
+    # cxl_df["MemoryType"] = "CXL"
+
+    dram_cxl_df = pd.read_csv(dram_cxl_csv_file).iloc[:, 0:4]
+    dram_cxl_df["MemoryType"] = "DRAM_CXL"
+
+    # https://stackoverflow.com/a/67148732
+    # TODO: Correct this so that indices 0, 2, 5, and 7 from 8 row blocks are captured
+    # TODO:     for reading DRAM to write to CXL
+    new = dram_cxl_df[dram_cxl_df.index.map(lambda i: i % 8 in (0, 2, 5, 7))]
+    print(new.to_string(max_rows=None))
+
+    # df = pd.concat([dram_df, cxl_df, dram_cxl_df])
+
+    # print(df)
+
+    # array_sizes = df["ArraySize"].drop_duplicates()
+    # functions = df["Function"].drop_duplicates()
+
+    # for array_size in array_sizes:
+    #     filtered = df[df["ArraySize"] == array_size]
+
+    #     for function in functions:
+    #         tmp_df = pd.DataFrame = ()
+
+    # print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/stream/scripts/stream_gen_csv.py
+++ b/benchmarks/stream/scripts/stream_gen_csv.py
@@ -13,7 +13,8 @@ ARRAY_SIZES: list[int] = [
     430_080_000,
 ]
 
-THREADS: list[int] = [4, 8, 16, 32, 64]
+# 1, 2, 4, 6, 8, ..., 32
+THREADS: list[int] = [1, *[x * 2 for x in range(1, 17)]]
 
 WHITESPACE_REPLACE = re.compile(r"\s+")
 
@@ -46,7 +47,8 @@ def run_cmd(cmd: str) -> str:
 # Example (while cd'd into this directory):
 # python3 stream_gen_csv.py ../stream_c.exe --numa-nodes 0
 def main() -> None:
-    parser = argparse.ArgumentParser(description="STREAM benchmarking tool runner")
+    parser = argparse.ArgumentParser(
+        description="STREAM benchmarking tool runner")
 
     parser.add_argument(
         "binary_path",
@@ -94,7 +96,8 @@ def main() -> None:
             lst.extend(formatted)
             end = time.time()
             elapsed = round(end - start, 3)
-            print(f"Done in {elapsed}s : {threads} threads, {array_size} array size")
+            print(
+                f"Done in {elapsed}s : {threads} threads, {array_size} array size")
 
     header = lst[0]
     filtered = list(filter(lambda x: x != header, lst))

--- a/benchmarks/stream/stream.c
+++ b/benchmarks/stream/stream.c
@@ -701,8 +701,8 @@ void checkSTREAMresults() {
         a1j = scalar * b2j;
         // iii. add node1-to-node2 (read a1, b1, write c2)
         c2j = a1j + b1j;
-        // iv. triad node2-to-node1 (read b2, c2, write a2)
-        a2j = b2j + scalar * c2j;
+        // iv. triad node2-to-node1 (read b2, c2, write a1)
+        a1j = b2j + scalar * c2j;
         // v. copy node2-to-node1 (read a2, write b1)
         b1j = a2j;
         // vi. scale node1-to-node2 (read b1, write a2)


### PR DESCRIPTION
- `stream.c` was corrected due to one of the triads only reading/writing from CXL. A compile option was missing for parallelization of for loops within `#omp parallel for` blocks, so everything was running on a single thread for a while, even though the environment variable `OMP_NUM_THREADS` was set.
- `stream_gen_csv.py` now has threads amounts of `1, 2, 4, 6, 8, ..., 32`.
- `graph_csv.py` was renamed to `graph_array_sizes.py`, legend for labels is now at the bottom of the graphs.
- `graph_operations.py` graphs different memory types per operation per array sizes in bulk.