### PR TITLE
[stream] Node directions in output

### DIFF
--- a/benchmarks/stream/scripts/csv_to_excel.py
+++ b/benchmarks/stream/scripts/csv_to_excel.py
@@ -22,8 +22,8 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    # Read CSV file, write to new Excel file
     df = pd.read_csv(args.csv_file)
-
     df.to_excel(args.output, index=False)
 
 

--- a/benchmarks/stream/scripts/graph_scripts/rate_by_operation.py
+++ b/benchmarks/stream/scripts/graph_scripts/rate_by_operation.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 import pandas as pd
 
-from utils import file_exists, int_to_human, smooth_line
+from utils import file_exists, int_to_human, smooth_line, remove_direction_column
 
 
 def main() -> None:
@@ -52,7 +52,7 @@ def main() -> None:
     if not os.path.isdir(directory):
         os.makedirs(directory)
 
-    df = pd.read_excel(csv_file).iloc[:, 0:4]
+    df = remove_direction_column(pd.read_excel(csv_file))
 
     array_sizes, functions = (
         args.array_sizes if args.array_sizes else df["ArraySize"].drop_duplicates(),

--- a/benchmarks/stream/scripts/graph_scripts/rate_by_operation_and_arraysize.py
+++ b/benchmarks/stream/scripts/graph_scripts/rate_by_operation_and_arraysize.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 import pandas as pd
 
-from utils import file_exists, smooth_line, int_to_human
+from utils import file_exists, smooth_line, int_to_human, remove_direction_column
 
 # Supressing a warning that appears when more than 20 figures are opened
 plt.rcParams["figure.max_open_warning"] = 0
@@ -71,7 +71,7 @@ def main() -> None:
     if not os.path.isdir(directory):
         os.makedirs(directory)
 
-    df = pd.read_excel(args.csv_file).iloc[:, 0:4]
+    df = remove_direction_column(pd.read_excel(args.csv_file))
 
     array_sizes, functions = (
         args.array_sizes if args.array_sizes else df["ArraySize"].drop_duplicates(),

--- a/benchmarks/stream/scripts/graph_scripts/rate_by_operation_and_memtype_direction.py
+++ b/benchmarks/stream/scripts/graph_scripts/rate_by_operation_and_memtype_direction.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 from matplotlib.ticker import FuncFormatter
 import pandas as pd
 
-from utils import file_exists, int_to_human, smooth_line
+from utils import file_exists, int_to_human, smooth_line, remove_direction_column
 
 # Supressing a warning that appears when more than 20 figures are opened
 plt.rcParams["figure.max_open_warning"] = 0
@@ -49,14 +49,15 @@ def main() -> None:
     if not os.path.isdir(directory):
         os.makedirs(directory)
 
-    df = pd.read_excel(args.csv_file).iloc[:, 0:4]
+    df = remove_direction_column(pd.read_excel(args.csv_file))
 
     array_sizes = df["ArraySize"].drop_duplicates()
     functions = df["Function"].drop_duplicates()
 
+    # https://stackoverflow.com/a/67148732 (filtering via index)
     dram_to_cxl_df, cxl_to_dram_df = (
-        df.copy()[df.index.map(lambda i: i % 8 in (0, 2, 5, 7))].reset_index(drop=True),
-        df.copy()[df.index.map(lambda i: i % 8 in (1, 3, 4, 6))].reset_index(drop=True),
+        df.copy()[df.index.map(lambda i: i % 8 in range(0, 4))],
+        df.copy()[df.index.map(lambda i: i % 8 in range(4, 8))],
     )
 
     dram_to_cxl_df["MemoryType"] = "DRAM to CXL"

--- a/benchmarks/stream/scripts/graph_scripts/rate_by_vendor_and_operation.py
+++ b/benchmarks/stream/scripts/graph_scripts/rate_by_vendor_and_operation.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 from matplotlib.ticker import FuncFormatter
 
-from utils import int_to_human, smooth_line
+from utils import int_to_human, smooth_line, remove_direction_column
 
 # Suppressing a warning that appears when more than 20 figures are opened
 plt.rcParams["figure.max_open_warning"] = 0
@@ -76,7 +76,10 @@ def main() -> None:
     if not os.path.isdir(directory):
         os.makedirs(directory)
 
-    dfs = [(pd.read_excel(f).iloc[:, 0:4], n) for (f, n) in csv_files]
+    dfs = [
+        (remove_direction_column(pd.read_excel(f)), n)
+        for (f, n) in csv_files
+    ]
 
     if not array_sizes:
         array_sizes = dfs[0][0]["ArraySize"].drop_duplicates()

--- a/benchmarks/stream/scripts/graph_scripts/utils/__init__.py
+++ b/benchmarks/stream/scripts/graph_scripts/utils/__init__.py
@@ -5,6 +5,7 @@ if __name__ == "graph_scripts.utils":
         scientific_notation,
     )
     from graph_scripts.utils.smoothing import smooth_line
+    from graph_scripts.utils.filtering import remove_direction_column
 else:
     from utils.files import file_exists, dump_file_name
     from utils.human_readable import (
@@ -12,6 +13,14 @@ else:
         scientific_notation,
     )
     from utils.smoothing import smooth_line
+    from utils.filtering import remove_direction_column
 
 
-__all__ = (file_exists, dump_file_name, int_to_human, scientific_notation, smooth_line)
+__all__ = (
+    file_exists,
+    dump_file_name,
+    int_to_human,
+    scientific_notation,
+    smooth_line,
+    remove_direction_column,
+)

--- a/benchmarks/stream/scripts/graph_scripts/utils/filtering.py
+++ b/benchmarks/stream/scripts/graph_scripts/utils/filtering.py
@@ -1,0 +1,10 @@
+import pandas as pd
+
+# TODO: Have this eventually be a function that only filters out columns passed by arg
+def remove_direction_column(df: pd.DataFrame) -> pd.DataFrame:
+    if "Direction" in df.columns:
+        df = df.iloc[:, 0:5].drop(["Direction"], axis=1)
+    else:
+        df = df.iloc[:, 0:4]
+
+    return df

--- a/benchmarks/stream/scripts/stream_generate_results.py
+++ b/benchmarks/stream/scripts/stream_generate_results.py
@@ -27,17 +27,66 @@ WHITESPACE_REPLACE = re.compile(r"\s+")
 def core_count_per_socket() -> list[int]:
     command = ["lscpu", "-p=SOCKET"]
     output = subprocess.check_output(command).decode("utf-8")
+
+    # Some motherboards have 2 sockets, we need to account for that
+    # because we only want the core count of one socket
     socket_count = len(set(x for x in output.split("\n")[4:] if len(x)))
     total_core_count = psutil.cpu_count(logical=False)
 
     cores = int(total_core_count / socket_count)
 
+    # 1, 2, 4, 6, ..., 32 (or whatever the core count might be)
     return [1, *[x * 2 for x in range(1, (cores // 2) + 1)]]
 
 
 def format_stream_output(
     s: str, thread_count: int, array_size: int
 ) -> list[list[int | str]]:
+    """
+    Parsing the output of STREAM for all the numbers that are important to us.
+
+    The rest of this docstring is an example of what STREAM outputs:
+
+    ```txt
+    -------------------------------------------------------------
+    STREAM version $Revision: 5.10 $
+    -------------------------------------------------------------
+    This system uses 8 bytes per array element.
+    -------------------------------------------------------------
+    Array size = 4000000 (elements), Offset = 0 (elements)
+    Memory per array = 30.5 MiB (= 0.0 GiB).
+    Total memory required = 91.6 MiB (= 0.1 GiB).
+    Each kernel will be executed 10 times.
+    The *best* time for each kernel (excluding the first iteration)
+    will be used to compute the reported bandwidth.
+    -------------------------------------------------------------
+    Number of Threads requested = 64
+    Number of Threads counted = 64
+    -------------------------------------------------------------
+    Your clock granularity/precision appears to be 1 microseconds.
+    Each test below will take on the order of 106 microseconds.
+    (= 106 clock ticks)
+    Increase the size of the arrays if this shows that
+    you are not getting at least 20 clock ticks per test.
+    -------------------------------------------------------------
+    WARNING -- The above is only a rough guideline.
+    For best results, please be sure you know the
+    precision of your system timer.
+    -------------------------------------------------------------
+    Function     Direction    BestRateMBs     AvgTime      MinTime      MaxTime
+    Copy:        0->1           1597830.1     0.000042     0.000040     0.000048
+    Scale:       0->1           1688273.3     0.000040     0.000038     0.000042
+    Add:         0->1           2003249.7     0.000051     0.000048     0.000056
+    Triad:       0->1           1954627.1     0.000051     0.000049     0.000053
+    Copy:        1->0           1688273.3     0.000039     0.000038     0.000040
+    Scale:       1->0           1777718.3     0.000038     0.000036     0.000039
+    Add:         1->0           2141772.3     0.000047     0.000045     0.000049
+    Triad:       1->0           2086285.9     0.000052     0.000046     0.000080
+    -------------------------------------------------------------
+    Solution Validates: avg error less than 1.000000e-13 on all three arrays
+    -------------------------------------------------------------
+    ```
+    """
     selected_output = s.splitlines()[-12:-3]
 
     lst: list[list[str]] = [
@@ -46,6 +95,7 @@ def format_stream_output(
 
     lst[0].insert(0, "ArraySize")
     lst[0].insert(0, "Threads")
+
     for i in range(1, len(lst)):
         lst[i][0] = lst[i][0].removesuffix(":")
         lst[i].insert(0, array_size)
@@ -54,6 +104,7 @@ def format_stream_output(
     return lst
 
 
+# Run a command, capture its output, return said output
 def run_cmd(cmd: str) -> str:
     returned_output = subprocess.check_output(cmd, shell=True)
 
@@ -129,7 +180,7 @@ def main() -> None:
         type=int,
         required=False,
         default=0,
-        help="The CPU socket which 'cpunodebind' is attached to"
+        help="The CPU socket which 'cpunodebind' is attached to",
     )
 
     args = parser.parse_args()

--- a/benchmarks/stream/scripts/vendor_to_excel.py
+++ b/benchmarks/stream/scripts/vendor_to_excel.py
@@ -6,7 +6,7 @@ import pandas as pd
 from openpyxl import load_workbook
 from openpyxl.worksheet.filters import FilterColumn, Filters
 
-from graph_scripts.utils import file_exists
+from graph_scripts.utils import file_exists, remove_direction_column
 
 
 def main() -> None:
@@ -28,15 +28,15 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    df = pd.read_excel(args.csv_file).iloc[:, 0:4]
+    df = remove_direction_column(pd.read_excel(args.csv_file))
 
     array_sizes = df["ArraySize"].drop_duplicates()
     functions = df["Function"].drop_duplicates()
     threads = df["Threads"].drop_duplicates()
 
     dram_to_cxl_df, cxl_to_dram_df = (
-        df.copy()[df.index.map(lambda i: i % 8 in (0, 2, 5, 7))].reset_index(drop=True),
-        df.copy()[df.index.map(lambda i: i % 8 in (1, 3, 4, 6))].reset_index(drop=True),
+        df.copy()[df.index.map(lambda i: i % 8 in range(0, 4))],
+        df.copy()[df.index.map(lambda i: i % 8 in range(4, 8))],
     )
 
     dram_to_cxl_df.rename(columns={"BestRateMBs": "DRAM to CXL"}, inplace=True)

--- a/benchmarks/stream/stream.c
+++ b/benchmarks/stream/stream.c
@@ -352,7 +352,7 @@ int main(int argc, char **argv) {
 #endif
         times[0][k] = mysecond() - times[0][k];
 
-        times[1][k] = mysecond();
+        times[5][k] = mysecond();
 #ifdef TUNED
         tuned_STREAM_Scale(scalar, a1, b2);
 #else
@@ -361,7 +361,7 @@ int main(int argc, char **argv) {
         for (j = 0; j < stream_array_size; j++)
             a1[j] = scalar * b2[j];
 #endif
-        times[1][k] = mysecond() - times[1][k];
+        times[5][k] = mysecond() - times[5][k];
 
         times[2][k] = mysecond();
 #ifdef TUNED
@@ -374,7 +374,7 @@ int main(int argc, char **argv) {
 #endif
         times[2][k] = mysecond() - times[2][k];
 
-        times[3][k] = mysecond();
+        times[7][k] = mysecond();
 #ifdef TUNED
         tuned_STREAM_Triad(scalar, a2, b2, c2);
 #else
@@ -383,7 +383,7 @@ int main(int argc, char **argv) {
         for (j = 0; j < stream_array_size; j++)
             a1[j] = b2[j] + scalar * c2[j];
 #endif
-        times[3][k] = mysecond() - times[3][k];
+        times[7][k] = mysecond() - times[7][k];
 
         times[4][k] = mysecond();
 #ifdef TUNED
@@ -396,7 +396,7 @@ int main(int argc, char **argv) {
 #endif
         times[4][k] = mysecond() - times[4][k];
 
-        times[5][k] = mysecond();
+        times[1][k] = mysecond();
 #ifdef TUNED
         tuned_STREAM_Scale(scalar, a2, b1);
 #else
@@ -405,7 +405,7 @@ int main(int argc, char **argv) {
         for (j = 0; j < stream_array_size; j++)
             a2[j] = scalar * b1[j];
 #endif
-        times[5][k] = mysecond() - times[5][k];
+        times[1][k] = mysecond() - times[1][k];
 
         times[6][k] = mysecond();
 #ifdef TUNED
@@ -418,7 +418,7 @@ int main(int argc, char **argv) {
 #endif
         times[6][k] = mysecond() - times[6][k];
 
-        times[7][k] = mysecond();
+        times[3][k] = mysecond();
 #ifdef TUNED
         tuned_STREAM_Triad(scalar, a2, b1, c1);
 #else
@@ -427,7 +427,7 @@ int main(int argc, char **argv) {
         for (j = 0; j < stream_array_size; j++)
             a2[j] = b1[j] + scalar * c1[j];
 #endif
-        times[7][k] = mysecond() - times[7][k];
+        times[3][k] = mysecond() - times[3][k];
     }
 
     /*	--- SUMMARY --- */
@@ -441,12 +441,20 @@ int main(int argc, char **argv) {
         }
     }
 
-    printf("Function        BestRateMBs AvgTime      MinTime      MaxTime\n");
+    printf(
+        "Function     Direction    BestRateMBs     AvgTime      MinTime      MaxTime\n");
     for (j = 0; j < TIMES_LEN; j++) {
         avgtime[j] = avgtime[j] / (double)(ntimes - 1);
 
-        printf("%s%12.1f  %11.6f  %11.6f  %11.6f\n", label[j % 4],
-               1.0E-06 * bytes[j] / mintime[j], avgtime[j], mintime[j], maxtime[j]);
+        if (j < (TIMES_LEN / 2)) {
+            printf("%s  %ld->%ld  %18.1f  %11.6f  %11.6f  %11.6f\n", label[j % 4],
+                   numa_nodes[0], numa_nodes[1], 1.0E-06 * bytes[j] / mintime[j],
+                   avgtime[j], mintime[j], maxtime[j]);
+        } else {
+            printf("%s  %ld->%ld  %18.1f  %11.6f  %11.6f  %11.6f\n", label[j % 4],
+                   numa_nodes[1], numa_nodes[0], 1.0E-06 * bytes[j] / mintime[j],
+                   avgtime[j], mintime[j], maxtime[j]);
+        }
     }
     printf(HLINE);
 


### PR DESCRIPTION
All scripts had to be modified to accommodate this new column. In the near future, parsing data should be more dynamic and not prone to breaking when more data is added. For now, this will do.

An example of DRAM to DRAM (node 0 to 1):

```
-------------------------------------------------------------
STREAM version $Revision: 5.10 $
-------------------------------------------------------------
This system uses 8 bytes per array element.
-------------------------------------------------------------
Array size = 4000000 (elements), Offset = 0 (elements)
Memory per array = 30.5 MiB (= 0.0 GiB).
Total memory required = 91.6 MiB (= 0.1 GiB).
Each kernel will be executed 10 times.
The *best* time for each kernel (excluding the first iteration)
will be used to compute the reported bandwidth.
-------------------------------------------------------------
Number of Threads requested = 64
Number of Threads counted = 64
-------------------------------------------------------------
Your clock granularity/precision appears to be 1 microseconds.
Each test below will take on the order of 106 microseconds.
(= 106 clock ticks)
Increase the size of the arrays if this shows that
you are not getting at least 20 clock ticks per test.
-------------------------------------------------------------
WARNING -- The above is only a rough guideline.
For best results, please be sure you know the
precision of your system timer.
-------------------------------------------------------------
Function     Direction    BestRateMBs     AvgTime      MinTime      MaxTime
Copy:        0->1           1597830.1     0.000042     0.000040     0.000048
Scale:       0->1           1688273.3     0.000040     0.000038     0.000042
Add:         0->1           2003249.7     0.000051     0.000048     0.000056
Triad:       0->1           1954627.1     0.000051     0.000049     0.000053
Copy:        1->0           1688273.3     0.000039     0.000038     0.000040
Scale:       1->0           1777718.3     0.000038     0.000036     0.000039
Add:         1->0           2141772.3     0.000047     0.000045     0.000049
Triad:       1->0           2086285.9     0.000052     0.000046     0.000080
-------------------------------------------------------------
Solution Validates: avg error less than 1.000000e-13 on all three arrays
-------------------------------------------------------------
```